### PR TITLE
Added constant for the Belfius Direct Net payment method.

### DIFF
--- a/Mollie.Api/Mollie.cs
+++ b/Mollie.Api/Mollie.cs
@@ -47,6 +47,7 @@ namespace Mollie.Api
 		mistercash,
 		sofort,
 		banktransfer,
+		belfius,
 		bitcoin,
 		paypal,
 		paysafecard,


### PR DESCRIPTION
We recently added Belfius Direct Net as a payment method. 
