### PR TITLE
Add ING homepay

### DIFF
--- a/Mollie.Api/Models/Method.cs
+++ b/Mollie.Api/Models/Method.cs
@@ -17,5 +17,6 @@ namespace Mollie.Api.Models
         paypal,
         paysafecard,
         giftcard,
+        inghomepay
     }
 }


### PR DESCRIPTION
Hello, we've released ING Home'Pay at Mollie.
So i added it to the method enum.

https://www.mollie.com/en/payments/ing-homepay